### PR TITLE
hsel improvements

### DIFF
--- a/cpp/hsel.cpp
+++ b/cpp/hsel.cpp
@@ -21,10 +21,11 @@
 
 #include "randbelow.h"
 
-std::unordered_map<uint32_t, uint32_t> hsel_options;
 
 extern "C" void random_hsel(uint32_t n, uint32_t k, uint32_t* result) {
-    hsel_options.clear();
+    std::unordered_map<uint32_t, uint32_t> hsel_options;
+    hsel_options.reserve(1.45*k); // give 45% extra space to keep load-factor low
+
     for (uint32_t i = 0; i != k; ++i) {
       result[i] = i;
     }

--- a/cpp/hsel.cpp
+++ b/cpp/hsel.cpp
@@ -24,20 +24,26 @@
 std::unordered_map<uint32_t, uint32_t> hsel_options;
 
 extern "C" void random_hsel(uint32_t n, uint32_t k, uint32_t* result) {
-  hsel_options.clear();
-  for (uint32_t i = 0; i != k; ++i) result[i] = i;
-  for (uint32_t i = 0; i != k; ++i) {
-    const uint32_t r = randbelow(n--) + i;
+    hsel_options.clear();
+    for (uint32_t i = 0; i != k; ++i) {
+      result[i] = i;
+    }
+    for (uint32_t i = 0; i != k; ++i) {
+        const uint32_t r = randbelow(n--) + i;
 
-    if(r >= k) {
-      const auto res_i = result[i];
-      const auto [fr, success] = hsel_options.emplace(r, res_i);
-      if(!success) {
-        result[i] = fr->second;
-        fr->second = res_i;
-      } else result[i] = r;
-    } else std::swap(result[i], result[r]);
-  }
+        if (r < k) {
+            std::swap(result[i], result[r]);
+        } else {
+            const auto res_i = result[i];
+            const auto [fr, success] = hsel_options.emplace(r, res_i);
+            if (success) {
+                result[i] = r;
+            } else {
+                result[i] = fr->second;
+                fr->second = res_i;
+            }
+        }
+    }
 }
 
 extern "C" void sorted_hsel(uint32_t n, uint32_t k, uint32_t* result) {

--- a/cpp/hsel.cpp
+++ b/cpp/hsel.cpp
@@ -21,23 +21,23 @@
 
 #include "randbelow.h"
 
+std::unordered_map<uint32_t, uint32_t> hsel_options;
+
 extern "C" void random_hsel(uint32_t n, uint32_t k, uint32_t* result) {
-    std::unordered_map<uint32_t, uint32_t> options(2 * k);
-    for (uint32_t i = 0; i < k; i++) {
-        uint32_t r = randbelow(n);
-        auto fr = options.find(r);
-        if (fr == options.end()) {
-            result[i] = r;
-        } else {
-            result[i] = fr->second;
-        }
-        auto fi = options.find(i);
-        if (fi == options.end()) {
-            options[r] = i;
-        } else {
-            options[r] = fi->second;
-        }
-    }
+  hsel_options.clear();
+  for (uint32_t i = 0; i != k; ++i) result[i] = i;
+  for (uint32_t i = 0; i != k; ++i) {
+    const uint32_t r = randbelow(n--) + i;
+
+    if(r >= k) {
+      const auto res_i = result[i];
+      const auto [fr, success] = hsel_options.emplace(r, res_i);
+      if(!success) {
+        result[i] = fr->second;
+        fr->second = res_i;
+      } else result[i] = r;
+    } else std::swap(result[i], result[r]);
+  }
 }
 
 extern "C" void sorted_hsel(uint32_t n, uint32_t k, uint32_t* result) {

--- a/cpp/meson.build
+++ b/cpp/meson.build
@@ -14,7 +14,7 @@
 
 project('sansreplace', ['c', 'cpp'],
     default_options : ['buildtype=debugoptimized', 'c_std=c11',
-'cpp_std=c++14'])
+'cpp_std=c++17'])
 
 add_project_arguments(
     '-fno-strict-aliasing', '-Ofast',


### PR DESCRIPTION
This PR improves `random_hsel` by
1. making the hash-map global to avoid paying construction+destruction each function call
2. replacing the hash-map with the `result` array in the lower (size-k) part of the virtual [0,n-1]-array

This makes `random_hsel` run faster than `cardchoose` for k > 60 on my machine.